### PR TITLE
set max length string field

### DIFF
--- a/georel/db/schema.cds
+++ b/georel/db/schema.cds
@@ -4,8 +4,8 @@ using { sap.common.CodeList } from '@sap/cds/common';
 
     entity CustomerProcesses {
         key processId : UUID;
-        customerName : String;
-        customerId : String;
+        customerName : String(40);
+        customerId : String(10);
         customerPhone : String;
         customerLanguage : String;
         customerCountry: String;


### PR DESCRIPTION
Column not visible in georel app. see https://github.tools.sap/BTP-E2EScenarioValidation/Validations/issues/341

Issue discussed with UI development https://support.wdf.sap.corp/sap/support/message/2280129148&saprole=ZCSSINTPROCE


see reply from development team

> Dear Tieyan,
 
> The column width calculation of the table works depending on the maxLength property for String fields. For those columns there is no maxLength is defined and in this case we assume that the data to be shown in the column is very long and set the column width to the maximum which is 20rem and those occupies too much space even for 3 columns.

> For your column please define the maxLength property in the backend and I believe the issue will be fixed.

> It is also true that this is recently changed, Previously we were not setting to the max width when maxLength is not defined but the new change is based on the UX requirements. 

> Best regards,
> Cahit
> UI5 Tables Dispatcher 